### PR TITLE
fix dep error lines

### DIFF
--- a/mk/automatic.mk
+++ b/mk/automatic.mk
@@ -21,13 +21,13 @@ SQUASHFS=$(shell command -v mksquashfs 2> /dev/null)
 
 # Ensure that `zsync` is installed already
 ifeq (,$(ZSYNC))
-	$(error zsync not found! Run deps.sh first.)
+$(error zsync not found! Run deps.sh first.)
 endif
 # Ensure that `xorriso` is installed already
 ifeq (,$(XORRISO))
-	$(error xorriso not found! Run deps.sh first.)
+$(error xorriso not found! Run deps.sh first.)
 endif
 # Ensure that `squashfs` is installed already
 ifeq (,$(SQUASHFS))
-	$(error squashfs-tools not found! Run deps.sh first.)
+$(error squashfs-tools not found! Run deps.sh first.)
 endif


### PR DESCRIPTION
With indentation the deps errors fail with:

`mk/automatic.mk:24: *** recipe commences before first target. Stop.`

removed indentation and they work if the dependencies are absent