### PR TITLE
Prevent the ISO build from removing nautilus / pop-desktop

### DIFF
--- a/config/pop-os/19.04.mk
+++ b/config/pop-os/19.04.mk
@@ -47,7 +47,6 @@ RM_PKGS=\
 	imagemagick-6.q16 \
 	pop-installer-session \
 	snapd \
-	tracker \
 	unattended-upgrades \
 	xul-ext-ubufox
 


### PR DESCRIPTION
Seems nautilus in 19.04 now requires tracker as a dependency