### PR TITLE
Use mirrors.ubuntu.com as package source

### DIFF
--- a/mk/chroot.mk
+++ b/mk/chroot.mk
@@ -9,7 +9,7 @@ $(BUILD)/debootstrap:
 		--arch=amd64 \
 		"$(UBUNTU_CODE)" \
 		"$@.partial" \
-		"$(UBUNTU_MIRROR)"; \
+		"$(DEBOOTSTRAP_MIRROR)"; \
 	then \
 		cat "$@.partial/debootstrap/debootstrap.log"; \
 		false; \

--- a/mk/ubuntu.mk
+++ b/mk/ubuntu.mk
@@ -25,7 +25,8 @@ else ifeq ($(DISTRO_VERSION),20.04)
 	UBUNTU_NAME:=Focal Fossa
 endif
 
-UBUNTU_MIRROR:=http://us.archive.ubuntu.com/ubuntu/
+DEBOOTSTRAP_MIRROR=http://us.archive.ubuntu.com/ubuntu/
+UBUNTU_MIRROR:=mirror://mirrors.ubuntu.com/mirrors.txt
 
 UBUNTU_COMPONENTS:=\
 	main \


### PR DESCRIPTION
This will select better sources for non-US users, and potentially improve package download speeds for all users.

Metadata download speeds may be negatively impacted, should be tested with a freshly installed ISO built from this branch.