### PR TITLE
Include "Nvidia" or "Intel" in volume label on 20.10

### DIFF
--- a/config/pop-os/18.04.mk
+++ b/config/pop-os/18.04.mk
@@ -1,5 +1,7 @@
 DISTRO_NAME=Pop_OS
 
+DISTRO_VOLUME_LABEL=$(DISTRO_NAME) $(DISTRO_VERSION) amd64
+
 # Repositories to be present in installed system
 DISTRO_REPOS=\
 	$(UBUNTU_REPOS) \

--- a/config/pop-os/19.04.mk
+++ b/config/pop-os/19.04.mk
@@ -1,5 +1,7 @@
 DISTRO_NAME=Pop_OS
 
+DISTRO_VOLUME_LABEL=$(DISTRO_NAME) $(DISTRO_VERSION) amd64
+
 # Repositories to be present in installed system
 DISTRO_REPOS=\
 	$(UBUNTU_REPOS) \

--- a/config/pop-os/20.04.mk
+++ b/config/pop-os/20.04.mk
@@ -1,5 +1,7 @@
 DISTRO_NAME=Pop_OS
 
+DISTRO_VOLUME_LABEL=$(DISTRO_NAME) $(DISTRO_VERSION) amd64
+
 # Repositories to be present in installed system
 DISTRO_REPOS=\
 	$(UBUNTU_REPOS) \

--- a/config/pop-os/20.10.mk
+++ b/config/pop-os/20.10.mk
@@ -1,5 +1,11 @@
 DISTRO_NAME=Pop_OS
 
+ifeq ($(NVIDIA),1)
+DISTRO_VOLUME_LABEL=$(DISTRO_NAME) $(DISTRO_VERSION) amd64 Nvidia
+else
+DISTRO_VOLUME_LABEL=$(DISTRO_NAME) $(DISTRO_VERSION) amd64 Intel
+endif
+
 # Repositories to be present in installed system
 DISTRO_REPOS=\
 	$(UBUNTU_REPOS) \

--- a/config/pxestick/18.04.mk
+++ b/config/pxestick/18.04.mk
@@ -3,6 +3,8 @@ DISTRO_NAME=PXEstick
 # Repositories to be present in installed system
 DISTRO_REPOS=$(UBUNTU_REPOS)
 
+DISTRO_VOLUME_LABEL=$(DISTRO_NAME) $(DISTRO_VERSION) amd64
+
 # Packages to install
 DISTRO_PKGS=\
 	linux-generic \

--- a/mk/iso.mk
+++ b/mk/iso.mk
@@ -168,7 +168,7 @@ ifeq ($(GRUB_BIOS),1)
 		-no-emul-boot -boot-load-size 4 -boot-info-table \
 		--grub2-boot-info --grub2-mbr /usr/lib/grub/i386-pc/boot_hybrid.img \
 		--efi-boot "boot/grub/efi.img" -efi-boot-part --efi-boot-image \
-		-r -V "$(DISTRO_NAME) $(DISTRO_VERSION) amd64" \
+		-r -V "$(DISTRO_VOLUME_LABEL)" \
 		-o "$@.partial" "$(BUILD)/iso" -- \
 		-volume_date all_file_dates ="$(DISTRO_EPOCH)"
 else
@@ -178,7 +178,7 @@ else
 		-no-emul-boot -boot-load-size 4 -boot-info-table \
 		-eltorito-alt-boot -e boot/grub/efi.img \
 		-no-emul-boot -isohybrid-gpt-basdat \
-		-r -V "$(DISTRO_NAME) $(DISTRO_VERSION) amd64" \
+		-r -V "$(DISTRO_VOLUME_LABEL)" \
 		-o "$@.partial" "$(BUILD)/iso" -- \
 		-volume_date all_file_dates ="$(DISTRO_EPOCH)"
 endif


### PR DESCRIPTION
This does not affect builds of previous releases.

Fixes https://github.com/pop-os/iso/issues/247.