### PR TITLE
feat: Migrate to DEB822 repositories for system repos on groovy

### DIFF
--- a/config/pop-os/20.10.mk
+++ b/config/pop-os/20.10.mk
@@ -1,8 +1,11 @@
 DISTRO_NAME=Pop_OS
 
+# DEB822 format system repositories, comment out to disable
+DEB822:=1
+APPS_URI:=http://apt.pop-os.org/proprietary
+
 # Repositories to be present in installed system
 DISTRO_REPOS=\
-	$(UBUNTU_REPOS) \
 	ppa:system76/pop
 
 # Add proposed repositories
@@ -11,10 +14,8 @@ DISTRO_REPOS+=\
 	ppa:system76/proposed
 endif
 
-# Add binary repository without source
-DISTRO_REPOS+=\
-	-- \
-	'deb http://apt.pop-os.org/proprietary $(UBUNTU_CODE) main'
+# Add repositories without source
+DISTRO_REPOS+=--
 
 # Packages to install
 DISTRO_PKGS=\

--- a/scripts/repos.sh
+++ b/scripts/repos.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Creates a .sources with the specified lines
+# The first argument should be the filename, ending in ".sources"
+# Subsequent arguments should be the required lines.
+
+set -e -x
+
+export DEBIAN_FRONTEND=noninteractive
+export HOME=/root
+export LC_ALL=C
+
+# Set up sources file
+echo "Creating ${FILENAME} sources file"
+echo "X-Repolib-Name: ${NAME}" > ${FILENAME}
+echo "Enabled: yes" >> ${FILENAME}
+echo "Types: ${TYPES}" >> ${FILENAME}
+echo "URIs: ${URIS}" >> ${FILENAME}
+echo "Suites: ${SUITES}" >> ${FILENAME}
+echo "Components: ${COMPONENTS}" >> ${FILENAME}


### PR DESCRIPTION
Build the ISO image with DEB822-format sources for the system sources and the Pop Proprietary Apps Repo. This only applies to 20.10 and later, and is done conditionally based on the contents of each version's .mk file

Required for pop-os/repoman#73
Requires pop-os/default-settings#97