### PR TITLE
Don't leak build environment env vars, or include .lanchpadlib

### DIFF
--- a/mk/automatic.mk
+++ b/mk/automatic.mk
@@ -19,6 +19,8 @@ SED=\
 	s|UBUNTU_CODE|$(UBUNTU_CODE)|g; \
 	s|UBUNTU_NAME|$(UBUNTU_NAME)|g
 
+CHROOT=env -i PATH=/usr/sbin:/usr/bin:/sbin:/bin chroot
+
 XORRISO=$(shell command -v xorriso 2> /dev/null)
 ZSYNC=$(shell command -v zsync 2> /dev/null)
 SQUASHFS=$(shell command -v mksquashfs 2> /dev/null)

--- a/mk/chroot.mk
+++ b/mk/chroot.mk
@@ -118,6 +118,8 @@ $(BUILD)/chroot: $(BUILD)/debootstrap
 	# Unmount chroot
 	"scripts/unmount.sh" "$@.partial"
 
+	sudo rm -rf "$@.partial"/root/.launchpadlib
+
 	# Remove temp directory for modifications
 	sudo rm -rf "$@.partial/iso"
 
@@ -193,6 +195,8 @@ $(BUILD)/live: $(BUILD)/chroot
 	# Unmount chroot
 	"scripts/unmount.sh" "$@.partial"
 
+	sudo rm -rf "$@.partial"/root/.launchpadlib
+
 	# Remove temp directory for modifications
 	sudo rm -rf "$@.partial/iso"
 
@@ -234,6 +238,8 @@ $(BUILD)/pool: $(BUILD)/chroot
 
 	# Unmount chroot
 	"scripts/unmount.sh" "$@.partial"
+
+	sudo rm -rf "$@.partial"/root/.launchpadlib
 
 	# Save package pool
 	sudo mv "$@.partial/iso/pool" "$@.partial/pool"

--- a/mk/chroot.mk
+++ b/mk/chroot.mk
@@ -40,7 +40,7 @@ $(BUILD)/chroot: $(BUILD)/debootstrap
 	"scripts/mount.sh" "$@.partial"
 
 	# Install dependencies of chroot script
-	sudo chroot "$@.partial" /bin/bash -e -c \
+	sudo $(CHROOT) "$@.partial" /bin/bash -e -c \
 		"UPDATE=1 \
 		UPGRADE=1 \
 		INSTALL=\"--no-install-recommends gnupg software-properties-common\" \
@@ -62,14 +62,14 @@ $(BUILD)/chroot: $(BUILD)/debootstrap
 	sudo cp "data/kernelstub" "$@.partial/etc/kernelstub/configuration"
 
 	# Workaround bug caused by first run of add-apt-repository being blank
-	sudo chroot "$@.partial" /bin/bash -e -c \
+	sudo $(CHROOT) "$@.partial" /bin/bash -e -c \
 		"add-apt-repository --yes -n ppa:system76/pop"
-	sudo chroot "$@.partial" /bin/bash -e -c \
+	sudo $(CHROOT) "$@.partial" /bin/bash -e -c \
 		"rm -rf /etc/apt/sources.list.d/system76-ubuntu-pop-$(UBUNTU_CODE).list"
 
 	# Setup DEB822 format repos on 20.10 or later
 	if [ -n "${DEB822}" ]; then \
-		sudo chroot "$@.partial" /bin/bash -e -c \
+		sudo $(CHROOT) "$@.partial" /bin/bash -e -c \
 			"FILENAME=\"/etc/apt/sources.list.d/system.sources\" \
 			NAME=\"${DISTRO_NAME} System Sources\" \
 			TYPES=\"deb deb-src\" \
@@ -80,7 +80,7 @@ $(BUILD)/chroot: $(BUILD)/debootstrap
 	fi
 
 	# Run chroot script
-	sudo chroot "$@.partial" /bin/bash -e -c \
+	sudo $(CHROOT) "$@.partial" /bin/bash -e -c \
 		"KEY=\"/iso/pop.key\" \
 		UPDATE=1 \
 		UPGRADE=1 \
@@ -94,7 +94,7 @@ $(BUILD)/chroot: $(BUILD)/debootstrap
 	
 	# Add extra URIS
 	if [ -n "${APPS_URI}" ]; then \
-		sudo chroot "$@.partial" /bin/bash -e -c \
+		sudo $(CHROOT) "$@.partial" /bin/bash -e -c \
 			"FILENAME=\"/etc/apt/sources.list.d/${DISTRO_CODE}-apps.sources\" \
 			NAME=\"${DISTRO_NAME} Applications\" \
 			TYPES=\"deb\" \
@@ -105,7 +105,7 @@ $(BUILD)/chroot: $(BUILD)/debootstrap
 	fi
 
 	# Rerun chroot script to install POST_DISTRO_PKGS
-	sudo chroot "$@.partial" /bin/bash -e -c \
+	sudo $(CHROOT) "$@.partial" /bin/bash -e -c \
 		"INSTALL=\"$(POST_DISTRO_PKGS)\" \
 		PURGE=\"$(RM_PKGS)\" \
 		AUTOREMOVE=1 \
@@ -125,7 +125,7 @@ $(BUILD)/chroot: $(BUILD)/debootstrap
 	sudo mv "$@.partial" "$@"
 
 $(BUILD)/chroot.tag: $(BUILD)/chroot
-	sudo chroot "$<" /bin/bash -e -c "dpkg-query -W --showformat='\$${Package}\t\$${Version}\n'" > "$@"
+	sudo $(CHROOT) "$<" /bin/bash -e -c "dpkg-query -W --showformat='\$${Package}\t\$${Version}\n'" > "$@"
 
 $(BUILD)/live: $(BUILD)/chroot
 	# Unmount chroot if mounted
@@ -160,7 +160,7 @@ $(BUILD)/live: $(BUILD)/chroot
 	sudo cp "data/prime-discrete" "$@.partial/etc/prime-discrete"
 
 	# Run chroot script
-	sudo chroot "$@.partial" /bin/bash -e -c \
+	sudo $(CHROOT) "$@.partial" /bin/bash -e -c \
 		"KEY=\"/iso/apt-cdrom.key\" \
 		INSTALL=\"$(LIVE_PKGS)\" \
 		PURGE=\"$(RM_PKGS)\" \
@@ -174,15 +174,15 @@ $(BUILD)/live: $(BUILD)/chroot
 	fi
 
 	# Update apt cache
-	sudo chroot "$@.partial" /usr/bin/apt-get update
+	sudo $(CHROOT) "$@.partial" /usr/bin/apt-get update
 
 	# Update appstream cache
 	if [ -e "$@.partial/usr/bin/appstreamcli" ]; then \
-		sudo chroot "$@.partial" /usr/bin/appstreamcli refresh-cache --force; \
+		sudo $(CHROOT) "$@.partial" /usr/bin/appstreamcli refresh-cache --force; \
 	fi
 
 	# Run console-setup script
-	sudo chroot "$@.partial" /bin/bash -e -c \
+	sudo $(CHROOT) "$@.partial" /bin/bash -e -c \
 		"/iso/console-setup.sh"
 
 	# Create missing network-manager file
@@ -200,7 +200,7 @@ $(BUILD)/live: $(BUILD)/chroot
 	sudo mv "$@.partial" "$@"
 
 $(BUILD)/live.tag: $(BUILD)/live
-	sudo chroot "$<" /bin/bash -e -c "dpkg-query -W --showformat='\$${Package}\t\$${Version}\n'" > "$@"
+	sudo $(CHROOT) "$<" /bin/bash -e -c "dpkg-query -W --showformat='\$${Package}\t\$${Version}\n'" > "$@"
 
 $(BUILD)/pool: $(BUILD)/chroot
 	# Unmount chroot if mounted
@@ -226,7 +226,7 @@ $(BUILD)/pool: $(BUILD)/chroot
 	"scripts/mount.sh" "$@.partial"
 
 	# Run chroot script
-	sudo chroot "$@.partial" /bin/bash -e -c \
+	sudo $(CHROOT) "$@.partial" /bin/bash -e -c \
 		"MAIN_POOL=\"$(MAIN_POOL)\" \
 		RESTRICTED_POOL=\"$(RESTRICTED_POOL)\" \
 		CLEAN=1 \

--- a/mk/update.mk
+++ b/mk/update.mk
@@ -19,7 +19,7 @@ update-chroot update-live: update-%: $(BUILD)/%
 	"scripts/mount.sh" "$<.partial"
 
 	# Run chroot script
-	sudo chroot "$<.partial" /bin/bash -e -c \
+	sudo $(CHROOT) "$<.partial" /bin/bash -e -c \
 		"UPDATE=1 \
 		UPGRADE=1 \
 		PURGE=\"$(RM_PKGS)\" \


### PR DESCRIPTION
This should fix https://github.com/pop-os/iso/issues/269, though it will have to be tested on Jenkins to verify. 

Looking at the files in `.launchpadlib` from the ISO, it looks like this was probably added by `add-apt-repository`, which uses launchpadlib to get the display name of a PPA.

Testing locally, I didn't end up with an extra home directory before this. But presumably it's some env var that's responsible for leaking the username `jenkins`, so clearing the env should prevent that. This should also generally prevent env vars for leaking and make builds more reproducible across systems.

In my local testing, the second commit prevents the filesystem from having a `.lanchpadlib` directory anywhere.