### PR TITLE
fix: add missing dep to fix offline install

### DIFF
--- a/config/pop-os/22.04.mk
+++ b/config/pop-os/22.04.mk
@@ -81,6 +81,7 @@ MAIN_POOL=\
 	libx86-1 \
 	lm-sensors \
 	pm-utils \
+	postfix \
 	powermgmt-base \
 	python3-debian \
 	python3-distro \


### PR DESCRIPTION
`apt-get` was failing to install because it couldn't find `postfix` while doing an offline install of 22.04.