### PR TITLE
feat: Compress ISOs with XZ

### DIFF
--- a/mk/iso.mk
+++ b/mk/iso.mk
@@ -36,7 +36,10 @@ $(BUILD)/iso_casper.tag: $(BUILD)/live $(BUILD)/chroot.tag $(BUILD)/live.tag $(B
 	sudo du -sx --block-size=1 "$(BUILD)/live" | cut -f1 > "$(BUILD)/iso/$(CASPER_PATH)/filesystem.size"
 
 	# Rebuild filesystem image
-	sudo mksquashfs "$(BUILD)/live" "$(BUILD)/iso/$(CASPER_PATH)/filesystem.squashfs" -noappend -fstime "$(DISTRO_EPOCH)"
+	sudo mksquashfs "$(BUILD)/live" \
+		"$(BUILD)/iso/$(CASPER_PATH)/filesystem.squashfs" \
+		-noappend -fstime "$(DISTRO_EPOCH)" \
+		-comp xz -b 1M -Xdict-size 1M -Xbcj x86
 
 	sudo chown -R "$(USER):$(USER)" "$(BUILD)/iso/$(CASPER_PATH)"
 


### PR DESCRIPTION
Might help with the Trubble build. Built an Intel Focal image locally (2.1G).
XZ should be better supported than Zstd for older releases of Ubuntu.