### PR TITLE
Add systemd to package dependencies

### DIFF
--- a/config/pop-os/22.04.mk
+++ b/config/pop-os/22.04.mk
@@ -25,6 +25,7 @@ DISTRO_PKGS=\
 	linux-system76 \
 	ubuntu-minimal \
 	ubuntu-standard \
+	systemd \
 	pop-desktop
 
 # Packages to install after (to avoid dependency issues)


### PR DESCRIPTION
Fixes pop os iso install (first noticed broken on debug 430)

One of it's dependencies wasn't being seein in the script (chrony) which was then causeing that package to be added to manifest-remove, so distinst tried to remove the package despite it being a hard dependency of systemd. Which then causes install to fail.