### PR TITLE
Add ubuntu-advantage-tools and ubuntu-minimal to remove list

### DIFF
--- a/config/pop-os/22.04.mk
+++ b/config/pop-os/22.04.mk
@@ -62,6 +62,8 @@ RM_PKGS=\
 	mozc-utils-gui \
 	pop-installer-session \
 	snapd \
+        ubuntu-advantage-tools \
+        ubuntu-minimal \
 	ubuntu-session \
 	ubuntu-wallpapers \
 	unattended-upgrades \


### PR DESCRIPTION
This causes `ubuntu-advantage-tools` and `ubuntu-minimal` to be explicitly removed during the creation of the live environment. (We don't want the former installed due to apt advertisements, while the latter is superseded by pop-desktop.)