### PR TITLE
Update links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ If you are considering filing a feature request, bug, or asking a question - ple
 
 General questions, feedback, and discussion topics **should not** be submitted to as an issue in the issue tracker. These should be posted on the [Pop\!\_OS Subreddit](https://reddit.com/r/pop_os), which represents the official community forum. It is there that ideas can be discussed, questions answered, and feedback reviewed. These things will actively be removed from the Issue Tracker if posted.
 
-Feature requests follow our contribution process. In order to understand how features get selected to be implemented into Pop\!\_OS, please read our [Development Approach doc](http://pop.system76.com/docs/pop-os-development-approach/). But anything that exists outside of what we may discover via Research & Modeling will travel through the following contribution process:
+Feature requests follow our contribution process. In order to understand how features get selected to be implemented into Pop\!\_OS, please read our [Development Approach doc](https://support.system76.com/articles/pop-os-development-approach). But anything that exists outside of what we may discover via Research & Modeling will travel through the following contribution process:
 
 * Idea and Brainstorming = [Subreddit](https://reddit.com/r/pop_os)
-* Under Consideration = [Pop\!\_Docs](http://pop.system76.com/docs)
+* Under Consideration = [Pop\!\_Docs](https://support.system76.com)
 * Approved and on Roadmap = ["On Roadmap" in Issue Tracker](https://github.com/system76/pop-distro/issues?q=is%3Aopen+is%3Aissue+label%3A%22On+Roadmap%22)


### PR DESCRIPTION
* Fixed broken links
    * For first link, last working [snapshot](https://web.archive.org/web/20190702143820/https://pop.system76.com/docs/pop-os-development-approach/) is from July 2019
    * For second link, last working [snapshot](https://web.archive.org/web/20190105025618/https://pop.system76.com/docs/) is from May 2019
        * Also unsure of what is meant, though closest page for Pop!\_OS docs now would be the System76 [support page](https://support.system76.com/)
* I also happened to upgrade any links using HTTP to HTTPS