### PR TITLE
Set `nvidia-drm.modeset` to `1`

### DIFF
--- a/config/pop-os/24.04.mk
+++ b/config/pop-os/24.04.mk
@@ -57,7 +57,7 @@ POST_DISTRO_PKGS+=rsync
 POST_DISTRO_PKGS+=systemd-boot
 
 #TODO: revisit whether these kernel params need to be explicitly invoked
-# This has been hard-set as a short term fix tide to the Nvidia ISOs'
+# This has been hard-set as a short term fix tied to the Nvidia ISOs'
 # inability to successfully reach a GUI session with the state of
 # COSMIC in the alpha ISO release.
 ifeq ($(NVIDIA),1)

--- a/config/pop-os/24.04.mk
+++ b/config/pop-os/24.04.mk
@@ -56,6 +56,10 @@ POST_DISTRO_PKGS+=rsync
 # added to pop-desktop and/or kernelstub
 POST_DISTRO_PKGS+=systemd-boot
 
+#TODO: revisit whether these kernel params need to be explicitly invoked
+# This has been hard-set as a short term fix tide to the Nvidia ISOs'
+# inability to successfully reach a GUI session with the state of
+# COSMIC in the alpha ISO release.
 ifeq ($(NVIDIA),1)
 DISTRO_PARAMS+=modules_load=nvidia
 DISTRO_PARAMS+=nvidia-drm.modeset=1

--- a/config/pop-os/24.04.mk
+++ b/config/pop-os/24.04.mk
@@ -58,7 +58,7 @@ POST_DISTRO_PKGS+=systemd-boot
 
 ifeq ($(NVIDIA),1)
 DISTRO_PARAMS+=modules_load=nvidia
-DISTRO_PARAMS+=nvidia-drm.modeset=0
+DISTRO_PARAMS+=nvidia-drm.modeset=1
 POST_DISTRO_PKGS+=\
 	amd-ppt-bin \
 	nvidia-driver-525


### PR DESCRIPTION
Changes `nvidia-drm.modeset` to `1` per https://github.com/pop-os/iso/issues/333

Does not address cosmic applications not launching in nvidia live-sessions, but does enable successfully launching the session, and combined with https://github.com/pop-os/linux/pull/332# should eliminate phantom displays and make is possible to successfully install from the nvidia ISO.